### PR TITLE
CUDA also uses bfloat16

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ python qwen-image-mps.py -p "A serene alpine lake at sunrise, ultra detailed, ci
 - Loads `Qwen/Qwen-Image` via `diffusers.DiffusionPipeline`
 - Selects device and dtype:
   - MPS: `bfloat16`
-  - CUDA: `float16`
+  - CUDA: `bfloat16`
   - CPU: `float32`
 - Uses a light positive conditioning suffix for quality
 - Generates at a 16:9 resolution (default `1664x928`)

--- a/qwen-image-mps.py
+++ b/qwen-image-mps.py
@@ -42,7 +42,7 @@ def main() -> None:
     elif torch.cuda.is_available():
         print("Using CUDA")
         device = "cuda"
-        torch_dtype = torch.float16
+        torch_dtype = torch.bfloat16
     else:
         print("Using CPU")
         device = "cpu"


### PR DESCRIPTION
See the code snippet from https://github.com/QwenLM/Qwen-Image:
```
# Load the pipeline
if torch.cuda.is_available():
    torch_dtype = torch.bfloat16
    device = "cuda"
```

The 50 samples as configured takes 43s on a NVIDIA RTX PRO 6000.